### PR TITLE
fix: 修复查看源代码链接指向正确的文档仓库

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ site_description: 新一代大模型网关与AI资产管理系统
 # Repository
 repo_name: QuantumNous/new-api
 repo_url: https://github.com/QuantumNous/new-api
+edit_uri: https://github.com/QuantumNous/new-api-docs/blob/main/docs/
 
 theme:
   name: material


### PR DESCRIPTION
## 问题描述

文档项目从 `new-api` 仓库迁移到独立的 `new-api-docs` 仓库后，MkDocs Material 主题生成的"查看本页的源代码"按钮仍然指向原仓库，导致链接失效。

### 具体表现
- 点击"查看本页的源代码"按钮后，跳转到类似 `https://github.com/QuantumNous/new-api/raw/master/docs/api/xxx.md` 的链接
- 由于文档可能已迁移，这些链接全部返回 404 错误

## 解决方案

在 `mkdocs.yml` 中添加 `edit_uri` 配置项，使"查看源代码"功能指向正确的文档仓库。

### 修改内容
```yaml
# Repository
repo_name: QuantumNous/new-api
repo_url: https://github.com/QuantumNous/new-api
edit_uri: https://github.com/QuantumNous/new-api-docs/blob/main/docs/  # 新增此行
```

## 效果
* ✅ 右上角的 GitHub 图标仍然正确指向主项目 `new-api`
* ✅ "查看本页的源代码"按钮现在指向文档仓库 `new-api-docs`
* ✅ 所有文档页面的源代码链接均可正常访问

## 测试
已在本地运行 `mkdocs serve` 测试，确认修改后的链接指向存在：
* 修改前：`https://github.com/QuantumNous/new-api/raw/master/docs/api/openai-chat.md` ❌
* 修改后：`https://github.com/QuantumNous/new-api-docs/blob/main/docs/api/openai-chat.md` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Edit on GitHub" links to the documentation site, allowing users to easily propose changes or improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->